### PR TITLE
restricted the accounts that this acts against

### DIFF
--- a/slack-bulkinviter.py
+++ b/slack-bulkinviter.py
@@ -35,10 +35,13 @@ channel_id = channels[0]['id']
 
 # Get users list
 response = slack.users.list()
-users = [(u['id'], u['name']) for u in response.body['members']]
+users = [(u['id'], u['name'], u['deleted'], u['is_bot'], u['is_restricted'], u['is_ultra_restricted']) for u in response.body['members']]
 
-# Invite all users to slack channel
-for user_id, user_name in users:
+# Invite all users to slack channel except single or multi-channel guests, bots, or deleted users.
+for user_id, user_name, user_deleted, user_is_bot, user_is_restricted, user_is_ultra_restricted in users:
+    if user_deleted == True or user_is_bot == True or user_is_restricted == True or user_is_ultra_restricted == True:
+        print("{} is deleted, bot, or guest; skipping".format(user_name))
+        continue
     print("Inviting {} to {}".format(user_name, channel_name))
     try:
         slack.channels.invite(channel_id, user_id)
@@ -46,8 +49,7 @@ for user_id, user_name in users:
         code = e.args[0]
         if code == "already_in_channel":
             print("{} is already in the channel".format(user_name))
-        elif code in ('cant_invite_self', 'cant_invite', 'user_is_ultra_restricted'):
+        elif code in ('cant_invite_self', 'cant_invite', 'user_is_ultra_restricted','ura_max_channels'):
             print("Skipping user {} ('{}')".format(user_name, code))
         else:
             raise
-


### PR DESCRIPTION
* Avoid too many requests by eliminating deleted users from the list to invite
* if you attempt to invite single-channel guests it was raising ura_max_channels
* we do NOT want to invite multi-channel guests that was a big suprise
* i'm not sure if the intent was to invite bots, we prefer not to.